### PR TITLE
enable plugin to overwrite profilename from job config as a parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,16 @@
         </dependency>
 
     </dependencies>
-
-</project>  
-  
-
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/src/main/java/org/jenkinsci/plugins/sharedobjects/SharedObjectJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/sharedobjects/SharedObjectJobProperty.java
@@ -78,8 +78,12 @@ public class SharedObjectJobProperty extends EnvInjectJobPropertyContributor {
                         restrictionActivated = false;
                     }
 
+                    // find out if profile name is a job argument
+                    Map<String, String> envVars = build.getEnvironment(listener);
+                    String real_profile = Util.replaceMacro(profiles, envVars);
+
                     if (restrictionActivated) {
-                        logger.info(String.format("Restricting shared objects to the following usage %s", profiles));
+                        logger.info(String.format("Restricting shared objects to the following usage %s", real_profile));
                     }
 
                     for (SharedObjectType type : sharedObjectTypes) {
@@ -88,7 +92,7 @@ public class SharedObjectJobProperty extends EnvInjectJobPropertyContributor {
                                 addSharedObject(result, type, build, logger);
                                 continue;
                             }
-                            if (restrictionActivated && isProfileActivated(profiles, type)) {
+                            if (restrictionActivated && isProfileActivated(real_profile, type)) {
                                 addSharedObject(result, type, build, logger);
                                 continue;
                             }


### PR DESCRIPTION
this enables the user to switch the profile for a job at each run ( profile as a job parameter ) without adapting the job configuration each time